### PR TITLE
Enhance keyword extraction with API fallback

### DIFF
--- a/arcana/pages/chatbot.py
+++ b/arcana/pages/chatbot.py
@@ -1,12 +1,9 @@
 import streamlit as st
 import openai
 from arcana.utils.response import openai_api_call
-import nltk
 
 # Ensure NLTK data is available before importing NLTK functions
 import arcana.utils.nltk_setup
-from nltk.tokenize import word_tokenize
-from nltk.corpus import stopwords
 from arcana.utils.fiber import FiberDBMS
 from arcana.core.config import INDEX_FILE, CACHE_DIR
 import os
@@ -541,13 +538,17 @@ def chatbot_page():
         # If a file HAS been processed, its context is already in the messages, so we skip this.
         if st.session_state.get('processed_file_name') is None:
             with st.spinner("Searching for relevant information..."):
-                stop_words = set(stopwords.words('english'))
-                words = word_tokenize(user_input)
-                keywords = [word for word in words if word.lower() not in stop_words and word.isalpha()]
-                
+                lang = detect_language(user_input)
+                keywords = extract_keywords(user_input, lang)
+
                 # Use the dbms instance from session state
-                results = dbms.query(" ".join(keywords), top_n=min(20, max(1, len(keywords))))
-                results = results[:5]
+                results = []
+                if keywords:
+                    results = dbms.query(
+                        " ".join(keywords[:20]),
+                        top_n=min(20, max(1, len(keywords)))
+                    )
+                    results = results[:5]
 
                 assistant_reply = ""
                 if results:
@@ -555,8 +556,10 @@ def chatbot_page():
                     for idx, result in enumerate(results, 1):
                         assistant_reply += f"**Result {idx} from `{result['name']}`:**\n"
                         assistant_reply += f"_{result['content']}_\n\n"
-                else:
+                elif keywords:
                     assistant_reply = "I couldn't find any specific information related to your query in the indexed documents."
+                else:
+                    assistant_reply = "I couldn't derive useful keywords from your query to search the indexed documents."
 
                 st.session_state.messages.append({"role": "system", "content": assistant_reply})
 

--- a/arcana/pages/flashcards.py
+++ b/arcana/pages/flashcards.py
@@ -2,24 +2,22 @@ import streamlit as st
 import json
 import re
 import datetime
-from nltk.tokenize import word_tokenize
-from nltk.corpus import stopwords
 from arcana.utils.response import openai_api_call
 from arcana.utils.fiber import FiberDBMS
 from arcana.core.config import INDEX_FILE
+from arcana.utils.indexing import extract_keywords, detect_language
 from openai.types.chat import ChatCompletionMessageParam
 
 
 def get_context_for_topic(dbms, topic):
     """Extracts keywords from a topic and queries the database for relevant context."""
-    stop_words = set(stopwords.words('english'))
-    words = word_tokenize(topic)
-    keywords = [word for word in words if word.lower() not in stop_words and word.isalpha()]
-    
+    lang = detect_language(topic)
+    keywords = extract_keywords(topic, lang)
+
     if not keywords:
         return ""
 
-    results = dbms.query(" ".join(keywords), top_n=10)
+    results = dbms.query(" ".join(keywords[:10]), top_n=10)
     
     if not results:
         return ""

--- a/arcana/pages/mixup.py
+++ b/arcana/pages/mixup.py
@@ -9,12 +9,11 @@ import requests
 
 # Ensure NLTK data is available before importing NLTK functions
 import arcana.utils.nltk_setup
-from nltk.tokenize import word_tokenize
-from nltk.corpus import stopwords
 
 from arcana.utils.response import openai_api_call
 from arcana.utils.fiber import FiberDBMS
 from arcana.core.config import GENERATED_FILES_DIR
+from arcana.utils.indexing import extract_keywords, detect_language
 from openai.types.chat import ChatCompletionMessageParam
 from pptx import Presentation
 from pptx.util import Inches, Pt
@@ -417,14 +416,13 @@ def init_study_guide_state(force_reset=False):
 
 def get_context_for_topic(dbms, topic):
     """Extracts keywords from a topic and queries the database for relevant context."""
-    stop_words = set(stopwords.words('english'))
-    words = word_tokenize(topic)
-    keywords = [word for word in words if word.lower() not in stop_words and word.isalpha()]
-    
+    lang = detect_language(topic)
+    keywords = extract_keywords(topic, lang)
+
     if not keywords:
         return "" # Return empty string if no keywords are found
 
-    results = dbms.query(" ".join(keywords), top_n=10)
+    results = dbms.query(" ".join(keywords[:10]), top_n=10)
     
     if not results:
         return "" # Return empty string if no context is found

--- a/arcana/utils/indexing.py
+++ b/arcana/utils/indexing.py
@@ -1,4 +1,6 @@
 import os
+from typing import Iterable, List
+
 import pandas as pd
 from docx import Document
 from pptx import Presentation
@@ -8,24 +10,81 @@ import nltk
 
 # Ensure NLTK data is available before importing NLTK functions
 import arcana.utils.nltk_setup
-from nltk.tokenize import word_tokenize
 from nltk.corpus import stopwords
 from PyPDF2 import PdfReader
 import csv
 import re
 import ast
+from openai.types.chat import ChatCompletionMessageParam
+
+from arcana.utils.response import openai_api_call
 from arcana.core.config import INDEX_FILE
 
 # NLTK data is now downloaded once in Arcanalte.py at startup.
 
-def extract_keywords(text, lang='en'):
-    # Handles both English and Chinese, and ignores emojis/symbols
+def extract_keywords(text, lang: str = 'en', minimum_nltk_keywords: int = 3) -> List[str]:
+    """Generate keyword tags for *text*.
+
+    NLTK is used first for fast, local keyword extraction. If NLTK fails to
+    surface a sufficient number of keywords, an OpenAI-compatible model is
+    called to generate higher quality tags. The model fallback is intentionally
+    lightweight and keeps the existing Fiber DBMS workflow unchanged.
+    """
+    nltk_keywords = _extract_keywords_with_nltk(text, lang)
+    if len(nltk_keywords) >= minimum_nltk_keywords:
+        return nltk_keywords
+
+    model_keywords = generate_keywords_with_model(text, lang)
+    # Fall back to the NLTK output if the API could not provide anything better
+    return model_keywords or nltk_keywords
+
+
+def _extract_keywords_with_nltk(text: str, lang: str) -> List[str]:
+    """Return keyword candidates using the existing NLTK pipeline."""
     stop_words = set(stopwords.words('english')) if lang == 'en' else set()
-    # Tokenize Chinese and English, keep CJK, ignore symbols/emojis
     words = re.findall(r'[\u4e00-\u9fff]+|[a-zA-Z]+', text)
     if lang == 'en':
         return [w for w in words if w.lower() not in stop_words]
     return words
+
+
+def generate_keywords_with_model(text: str, lang: str = 'en', max_keywords: int = 10) -> List[str]:
+    """Use the hosted model API to derive concise keyword tags for a text."""
+    if not text.strip():
+        return []
+
+    prompt = (
+        "Extract up to {max_keywords} concise search keywords for the following "
+        "text. Respond with a comma-separated list of lowercase keywords only. "
+        "Avoid stop words and duplicates."
+    ).format(max_keywords=max_keywords)
+
+    user_content = f"Language: {lang}\nText: {text.strip()}"
+    messages: Iterable[ChatCompletionMessageParam] = [
+        {"role": "system", "content": "You create keyword tags for fast document search."},
+        {"role": "user", "content": f"{prompt}\n\n{user_content}"},
+    ]
+
+    try:
+        response_text = ''.join(openai_api_call(messages, "Idx")).strip()
+    except Exception as exc:  # pragma: no cover - defensive programming
+        print(f"Keyword generation API failed: {exc}")
+        return []
+
+    if not response_text:
+        return []
+
+    # Accept comma, newline, or semicolon separated keywords
+    raw_keywords = re.split(r'[\n;,]', response_text)
+    cleaned_keywords: List[str] = []
+    seen = set()
+    for keyword in raw_keywords:
+        cleaned = re.sub(r'[^\w\u4e00-\u9fff]+', '', keyword.strip().lower())
+        if cleaned and cleaned not in seen:
+            cleaned_keywords.append(cleaned)
+            seen.add(cleaned)
+
+    return cleaned_keywords[:max_keywords]
 
 def detect_language(text):
     # Simple check: if contains CJK, treat as Chinese


### PR DESCRIPTION
## Summary
- add a model-powered keyword generation fallback that augments the existing NLTK extraction during indexing
- reuse the improved keyword extraction when querying for context in the chatbot, flashcards, and mixup pages

## Testing
- python -m compileall arcana

------
https://chatgpt.com/codex/tasks/task_e_68e91118f2b88331a743878e091cb9fd