### PR TITLE
Add deep reasoning mode to chatbot

### DIFF
--- a/arcana/pages/chatbot.py
+++ b/arcana/pages/chatbot.py
@@ -520,11 +520,12 @@ def chatbot_page():
         with col2:
             response_type = st.selectbox(
                 "Mode",
-                ["Normal", "IDX", "Math"],
+                ["Normal", "IDX", "Math", "Reasoning"],
                 help="""
                 **Normal**: General conversation with search context
                 **IDX**: Strictly based on indexed files
                 **Math**: Specialized for mathematical queries
+                **Reasoning**: Uses a deep reasoning model that thinks step-by-step before replying
                 """,
                 label_visibility="collapsed"
             )
@@ -569,9 +570,20 @@ def chatbot_page():
                 if 'processed_file_name' not in st.session_state:
                     st.session_state.processed_file_name = None
 
+                messages_to_send = list(st.session_state.messages)
+                if response_type == "Reasoning":
+                    messages_to_send.append({
+                        "role": "system",
+                        "content": (
+                            "You are in deep reasoning mode. Think through the problem step by step before answering. "
+                            "Provide a thorough explanation that breaks complex ideas into clear stages so the user can "
+                            "understand the concept deeply."
+                        )
+                    })
+
                 with st.chat_message("assistant"):
                     # Use st.write_stream to render the response in real-time
-                    response_generator = openai_api_call(st.session_state.messages, response_type)
+                    response_generator = openai_api_call(messages_to_send, response_type)
                     collected_chunks = []
 
                     def stream_and_collect():
@@ -581,6 +593,11 @@ def chatbot_page():
 
                     st.write_stream(stream_and_collect())
                     full_response = "".join(collected_chunks)
+
+                    if response_type == "Reasoning" and response_generator.has_reasoning():
+                        with st.expander("Show Arcana's reasoning", expanded=False):
+                            reasoning_text = response_generator.reasoning.replace("\n", "  \n")
+                            st.markdown(reasoning_text or "(Reasoning trace was empty.)")
                 
                 # Append the full response to the message history
                 st.session_state.messages.append({"role": "assistant", "content": full_response})

--- a/arcana/utils/response.py
+++ b/arcana/utils/response.py
@@ -1,35 +1,113 @@
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, Iterator, List, Optional
+
 from openai import OpenAI
 from openai.types.chat import ChatCompletionMessageParam
-from typing import Generator, List, Dict, Any, Iterable
+
 
 client = OpenAI(
-    base_url='https://dashscope.aliyuncs.com/compatible-mode/v1',
+    base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
     api_key="sk-e8dfa404853d43e9870570c6c98c9516",
 )
 
 online = True
-search_mode=1
-def openai_api_call(messages: Iterable[ChatCompletionMessageParam], mode: str = 'Normal') -> Generator[str, None, None]:
-    """
-    Calls the OpenAI-compatible API with the given messages and streams the response.
-    This function is a generator that yields the content chunks.
-    """
-    model_map = {
-        'Normal': 'qwen-plus',
-        'Math': 'llama-4-maverick-17b-128e-instruct',
-        'Long Text': 'qwen-long',
-        'Idx': 'qwen-turbo'
-    }
-    model = model_map.get(mode.title(), 'qwen-turbo')
+search_mode = 1
 
-    try:
-        stream = client.chat.completions.create(
+
+@dataclass
+class ResponseStream:
+    """Wrapper around the streaming API response.
+
+    This class keeps track of streamed content chunks as well as any
+    "reasoning" tokens emitted by compatible models while still behaving like
+    an iterable of string chunks.
+    """
+
+    stream_factory: Callable[[], Iterator]
+    reasoning_chunks: List[str] = field(default_factory=list)
+    error: Optional[str] = None
+    _consumed: bool = False
+
+    def __iter__(self) -> Iterator[str]:
+        if self._consumed:
+            # Generators returned by ``stream_factory`` are one-shot. If the
+            # caller attempts to iterate again we simply yield nothing to avoid
+            # re-triggering the API call.
+            return iter(())
+
+        self._consumed = True
+
+        def iterator() -> Iterator[str]:
+            try:
+                stream = self.stream_factory()
+                for chunk in stream:
+                    if not chunk.choices:
+                        continue
+
+                    delta = chunk.choices[0].delta
+
+                    reasoning_piece = getattr(delta, "reasoning_content", None)
+                    if reasoning_piece:
+                        self.reasoning_chunks.append(reasoning_piece)
+
+                    content_piece = getattr(delta, "content", None)
+                    if content_piece:
+                        yield content_piece
+            except Exception as exc:  # pragma: no cover - network dependent
+                self.error = str(exc)
+                yield f"An error occurred: {self.error}"
+
+        return iterator()
+
+    @property
+    def reasoning(self) -> str:
+        """Full reasoning text emitted by the model, if any."""
+
+        return "".join(self.reasoning_chunks).strip()
+
+    def has_reasoning(self) -> bool:
+        return bool(self.reasoning)
+
+
+def openai_api_call(
+    messages: Iterable[ChatCompletionMessageParam],
+    mode: str = "Normal",
+) -> ResponseStream:
+    """
+    Calls the OpenAI-compatible API with the given messages and streams the
+    response.
+
+    Parameters
+    ----------
+    messages:
+        An iterable of chat completion message payloads.
+    mode:
+        The reasoning mode that should be used. Determines which underlying
+        model (and optional extra parameters) are utilised.
+    """
+
+    normalized_mode = mode.title()
+    model_map = {
+        "Normal": "qwen-plus",
+        "Math": "llama-4-maverick-17b-128e-instruct",
+        "Long Text": "qwen-long",
+        "Idx": "qwen-turbo",
+        "Reasoning": "qwen-plus-2025-04-28",
+    }
+
+    model = model_map.get(normalized_mode, "qwen-turbo")
+    messages_list = list(messages)
+
+    extra_body = {}
+    if normalized_mode == "Reasoning":
+        extra_body["enable_thinking"] = True
+
+    def factory() -> Iterator:
+        return client.chat.completions.create(
             model=model,
-            messages=messages,
+            messages=messages_list,
             stream=True,
+            **({"extra_body": extra_body} if extra_body else {}),
         )
-        for chunk in stream:
-            if chunk.choices and chunk.choices[0].delta and chunk.choices[0].delta.content:
-                yield chunk.choices[0].delta.content
-    except Exception as e:
-        yield f"An error occurred: {str(e)}"
+
+    return ResponseStream(stream_factory=factory)


### PR DESCRIPTION
## Summary
- wrap streamed responses in a ResponseStream helper to capture model reasoning traces
- add a new deep reasoning mode that uses the qwen-plus-2025-04-28 model with thinking enabled
- expose the reasoning mode in the chatbot UI and surface the model's reasoning in an optional expander

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ea7eaa60808331bad9fcbac6f7967d