### PR TITLE
Harden underline parsing for mixed formatting

### DIFF
--- a/arcana/pages/mixup.py
+++ b/arcana/pages/mixup.py
@@ -127,7 +127,7 @@ def parse_markdown_inline(text):
         (r'\*\*(.*?)\*\*', 'bold'),      # **bold**
         (r'(?<!\*)\*([^*]+?)\*(?!\*)', 'italic'),  # *italic* (not part of **)
         (r'`(.*?)`', 'code'),            # `code`
-        (r'_\_(.*?)__', 'underline'),    # __underline__
+        (r'(?<!_)__(?!_)(.+?)(?<!_)__(?!_)', 'underline'),    # __underline__ (not part of ___)
         (r'(?<!_)_([^_]+?)_(?!_)', 'italic'),      # _italic_ (not part of __)
         (r'\[(.*?)\]\((.*?)\)', 'link'), # [text](url)
     ]

--- a/arcana/tests/test_mixed_formatting.py
+++ b/arcana/tests/test_mixed_formatting.py
@@ -1,0 +1,33 @@
+"""Tests for the mixed markdown formatting parser."""
+
+from docx import Document
+
+from scripts.mixup import parse_markdown_to_word_runs
+
+
+def test_parse_markdown_to_word_runs_handles_underline_formatting():
+    """The parser should treat ``__text__`` as underlined content."""
+
+    document = Document()
+    paragraph = document.add_paragraph()
+
+    parse_markdown_to_word_runs(paragraph, "Start __underlined__ end")
+
+    underline_runs = [run for run in paragraph.runs if run.text == "underlined"]
+
+    assert underline_runs, "Expected an underlined run for the wrapped text"
+    assert all(run.font.underline for run in underline_runs), "Underline formatting was not applied"
+
+
+def test_parse_markdown_to_word_runs_ignores_triple_underscores():
+    """Triple underscores should not be misinterpreted as underline markers."""
+
+    document = Document()
+    paragraph = document.add_paragraph()
+
+    parse_markdown_to_word_runs(paragraph, "Stay ___plain___ text")
+
+    triple_run = next((run for run in paragraph.runs if "plain" in run.text), None)
+
+    assert triple_run is not None, "Expected to retain the text wrapped in triple underscores"
+    assert triple_run.font.underline is not True, "Triple underscores should not produce underlined runs"


### PR DESCRIPTION
## Summary
- tighten the underline detection regex so `__text__` is parsed without stealing triple-underscore sequences
- add a regression test covering both valid underline markup and triple underscore text remaining plain

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eb4f3698348331a366143510f9c5a6