### PR TITLE
Update Mixup imports to use refactored utilities

### DIFF
--- a/arcana/pages/mixup.py
+++ b/arcana/pages/mixup.py
@@ -11,9 +11,9 @@ import requests
 import arcana.nltk_setup
 from arcana.nltk_setup import safe_word_tokenize as word_tokenize, safe_stopwords as stopwords
 
-from response import openai_api_call
-from arcana.fiber import FiberDBMS
-from scripts.config import GENERATED_FILES_DIR
+from arcana.utils.response import openai_api_call
+from arcana.utils.fiber import FiberDBMS
+from arcana.core.config import GENERATED_FILES_DIR
 from openai.types.chat import ChatCompletionMessageParam
 from pptx import Presentation
 from pptx.util import Inches, Pt


### PR DESCRIPTION
## Summary
- switch Mixup page to use the refactored response, fiber, and configuration modules
- confirm no remaining references rely on the removed top-level modules

## Testing
- streamlit run Arcanalte.py --server.headless true --server.port 8502
- pytest arcana/tests/test_markdown_parser.py arcana/tests/test_page_count.py *(fails: ModuleNotFoundError: No module named 'arcana.nltk_setup')*

------
https://chatgpt.com/codex/tasks/task_e_68eb5d0d5c988331bbed4a933f27e217