### PR TITLE
Add customizable themes to settings page

### DIFF
--- a/arcana/pages/settings.py
+++ b/arcana/pages/settings.py
@@ -1,56 +1,137 @@
 import streamlit as st
 
+
 def apply_theme():
-    """
-    Applies the selected theme by injecting custom CSS.
-    """
+    """Apply the selected theme by injecting custom CSS and toggling attributes."""
+
     if "theme" not in st.session_state:
         st.session_state.theme = "Light"
 
-    if st.session_state.theme == "Dark":
-        dark_mode_css = """
-        <style>
-        .stApp {
-            background-color: #1a1a1a;
-            color: #ffffff;
-        }
-        [data-testid="stSidebar"] {
-            background-color: #2e2e2e;
-        }
-        .stButton>button {
-            background-color: #4f4f4f;
-            color: #ffffff;
-            border: 1px solid #4f4f4f;
-        }
-        .stTextInput>div>div>input, .stTextArea>div>div>textarea {
-            background-color: #2e2e2e;
-            color: #ffffff;
-        }
-        h1, h2, h3, h4, h5, h6 {
-            color: #ffffff;
-        }
-        </style>
-        """
-        st.markdown(dark_mode_css, unsafe_allow_html=True)
+    theme_css = """
+    <style>
+    html[data-theme="Light"] .stApp {
+        background: #f5f5f8;
+        color: #1f1f1f;
+    }
+    html[data-theme="Light"] [data-testid="stSidebar"] {
+        background-color: #ffffff;
+        border-right: 1px solid rgba(0, 0, 0, 0.08);
+    }
+    html[data-theme="Light"] .stButton>button,
+    html[data-theme="Light"] .stSelectbox>div>div {
+        color: #1f1f1f;
+    }
+
+    html[data-theme="Dark"] .stApp {
+        background-color: #101010;
+        color: #f7f7f7;
+    }
+    html[data-theme="Dark"] [data-testid="stSidebar"] {
+        background-color: #1f1f1f;
+    }
+    html[data-theme="Dark"] .stButton>button {
+        background-color: #2b2b2b;
+        color: #f7f7f7;
+        border: 1px solid #3a3a3a;
+    }
+    html[data-theme="Dark"] .stTextInput>div>div>input,
+    html[data-theme="Dark"] .stTextArea>div>div>textarea,
+    html[data-theme="Dark"] .stSelectbox>div>div>div {
+        background-color: #1f1f1f;
+        color: #f7f7f7;
+        border-color: #3a3a3a;
+    }
+    html[data-theme="Dark"] h1,
+    html[data-theme="Dark"] h2,
+    html[data-theme="Dark"] h3,
+    html[data-theme="Dark"] h4,
+    html[data-theme="Dark"] h5,
+    html[data-theme="Dark"] h6 {
+        color: #ffffff;
+    }
+
+    html[data-theme="Glass"] .stApp {
+        background: linear-gradient(135deg, rgba(20, 24, 35, 0.85), rgba(33, 45, 62, 0.75)),
+                    url('https://images.unsplash.com/photo-1527443224154-dcc76ee9bc02?auto=format&fit=crop&w=1350&q=80') center/cover fixed;
+        color: #f0f4ff;
+    }
+    html[data-theme="Glass"] [data-testid="stSidebar"],
+    html[data-theme="Glass"] .stApp header,
+    html[data-theme="Glass"] .stApp section,
+    html[data-theme="Glass"] .stApp footer {
+        background: rgba(15, 20, 30, 0.35);
+        backdrop-filter: blur(18px);
+    }
+    html[data-theme="Glass"] .stButton>button,
+    html[data-theme="Glass"] .stSelectbox>div>div,
+    html[data-theme="Glass"] .stTextInput>div>div>input,
+    html[data-theme="Glass"] .stTextArea>div>div>textarea {
+        background: rgba(255, 255, 255, 0.12);
+        color: #f6fbff;
+        border: 1px solid rgba(255, 255, 255, 0.35);
+    }
+    html[data-theme="Glass"] .stButton>button svg,
+    html[data-theme="Glass"] .stSidebar .stButton>button svg,
+    html[data-theme="Glass"] .stSidebar [data-testid="stMarkdownContainer"] svg {
+        opacity: 0.65;
+    }
+    html[data-theme="Glass"] h1,
+    html[data-theme="Glass"] h2,
+    html[data-theme="Glass"] h3,
+    html[data-theme="Glass"] h4,
+    html[data-theme="Glass"] h5,
+    html[data-theme="Glass"] h6 {
+        color: #f6fbff;
+        text-shadow: 0 4px 16px rgba(0, 0, 0, 0.45);
+    }
+    </style>
+    """
+
+    st.markdown(theme_css, unsafe_allow_html=True)
+    st.markdown(
+        f"""
+        <script>
+        const root = window.parent.document.documentElement;
+        if (root) {{
+            root.setAttribute('data-theme', '{st.session_state.theme}');
+        }}
+        </script>
+        """,
+        unsafe_allow_html=True,
+    )
 
 # Function for the settings page
 def settings_page():
-    st.title("Settings")
-    st.write("Customize your chatbot experience.")
-
-    # Store the selected theme in session_state
     if "theme" not in st.session_state:
         st.session_state.theme = "Light"
 
-    # Dropdown for theme selection
-    theme = st.selectbox("Choose a theme:", ["Light", "Dark"], index=["Light", "Dark"].index(st.session_state.theme))
+    apply_theme()
 
-    # Update the theme in session_state when a new theme is selected
+    st.title("Settings")
+    st.write("Customize your chatbot experience.")
+
+    theme_options = ["Light", "Dark", "Glass"]
+    theme = st.selectbox(
+        "Choose a theme:",
+        theme_options,
+        index=theme_options.index(st.session_state.theme),
+        help="Select between a classic light interface, a dark night mode, or the deluxe glass aesthetic.",
+    )
+
     if theme != st.session_state.theme:
         st.session_state.theme = theme
-        st.rerun()  # Rerun the app to apply the theme change
+        rerun = getattr(st, "rerun", None)
+        if callable(rerun):
+            rerun()
+        else:
+            st.experimental_rerun()
 
-    st.write(f"Selected theme: {st.session_state.theme}")
+    descriptions = {
+        "Light": "Bright day mode with crisp contrast for maximum readability.",
+        "Dark": "Night mode with deep blacks designed for low-light environments.",
+        "Glass": "Glassmorphism-inspired mode with translucent panels and glowing typography.",
+    }
+    st.info(descriptions.get(st.session_state.theme, ""))
 
     # --- Update Log ---
     with st.expander("View Update Log"):
@@ -94,9 +175,4 @@ def settings_page():
             st.markdown(f"<div class='changelog-box'>{changelog}</div>", unsafe_allow_html=True)
         else:
             st.info("No changelog available yet.")
-
-    # The call to apply_theme() has been removed as it was causing a NameError.
-    # To change the theme, please use the built-in Streamlit settings menu
-    # (click the three dots in the top-right corner).
-    # apply_theme()
 


### PR DESCRIPTION
## Summary
- add UI controls in the Settings page to choose between Light, Dark, and Glass themes
- inject themed CSS for each mode and toggle the active theme via a document attribute
- reapply the interface immediately after switching themes with a rerun fallback

## Testing
- python -m compileall arcana/pages/settings.py

------
https://chatgpt.com/codex/tasks/task_e_68eb617f3e2c83318f3b5de92a73f36f