### PR TITLE
Add agent summarization tool and chat toolbar enhancements

### DIFF
--- a/arcana/pages/chatbot.py
+++ b/arcana/pages/chatbot.py
@@ -20,6 +20,7 @@ import requests
 import xml.etree.ElementTree as ET
 from html import unescape
 from arcana.utils.indexing import extract_keywords, detect_language
+from arcana.utils.document_agent import AgentSummaryResult, get_document_agent
 
 
 BASE_SYSTEM_PROMPT = (
@@ -654,6 +655,28 @@ def chatbot_page():
         color: #374151;
         margin-bottom: 8px;
     }
+
+    .arcana-toolbar {
+        background-color: #f9fafb;
+        border: 1px solid #e5e7eb;
+        border-radius: 12px;
+        padding: 12px 16px 6px;
+        margin: 16px 0;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+    }
+
+    .arcana-toolbar .toolbar-title {
+        font-weight: 600;
+        color: #1f2937;
+        font-size: 0.9rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        margin-bottom: 0.5rem;
+    }
+
+    .arcana-toolbar div[data-testid="stHorizontalBlock"] {
+        margin-bottom: 0.2rem;
+    }
     </style>
     """, unsafe_allow_html=True)
 
@@ -841,10 +864,13 @@ def chatbot_page():
     # User input area
     user_input = st.chat_input("Ask me anything about your documents...")
 
-    # Response type selector (more compact)
+    # Response toolbar directly beneath the input
     with st.container():
-        col1, col2 = st.columns([3, 1])
-        with col1:
+        st.markdown("<div class=\"arcana-toolbar\">", unsafe_allow_html=True)
+        st.markdown("<div class=\"toolbar-title\">Assistant tools</div>", unsafe_allow_html=True)
+        toolbar_cols = st.columns([1.5, 1.5, 1], gap="medium")
+        with toolbar_cols[0]:
+            st.markdown("**Web Search**")
             web_supplement_enabled = st.checkbox(
                 "Web supplement (Bing)",
                 help=(
@@ -852,8 +878,10 @@ def chatbot_page():
                     " supplement your indexed documents."
                 ),
                 key="web_supplement_enabled",
+                label_visibility="collapsed",
             )
-        with col2:
+        with toolbar_cols[1]:
+            st.markdown("**Assistant Mode**")
             response_type = st.selectbox(
                 "Mode",
                 ["Normal", "IDX", "Math", "Reasoning"],
@@ -863,8 +891,20 @@ def chatbot_page():
                 **Math**: Specialized for mathematical queries
                 **Reasoning**: Uses a deep reasoning model that thinks step-by-step before replying
                 """,
-                label_visibility="collapsed"
+                label_visibility="collapsed",
             )
+        with toolbar_cols[2]:
+            st.markdown("**Agent Mode**")
+            agent_mode_enabled = st.checkbox(
+                "Agent Mode",
+                help=(
+                    "When enabled, Arcana's agent reads full documents, generates summaries, "
+                    "and stores them for future chats before answering."
+                ),
+                key="agent_mode_enabled",
+                label_visibility="collapsed",
+            )
+        st.markdown("</div>", unsafe_allow_html=True)
 
     if user_input:
         st.session_state.pending_sources_default = "Sources: No sources cited."
@@ -874,14 +914,21 @@ def chatbot_page():
         
         # If a file has NOT been processed, search the database for context.
         # If a file HAS been processed, its context is already in the messages, so we skip this.
+        results: List[dict] = []
+        search_attempts: List[Tuple[str, int]] = []
+        keywords: List[str] = []
+        keyword_generation_raw = ""
+        keyword_source = "n/a"
+        bing_results: List[dict] = []
+        news_sensitive_query = False
+        agent_summary_results: List[AgentSummaryResult] = []
+
         if st.session_state.get('processed_file_name') is None:
             with st.spinner("Searching for relevant information..."):
                 lang = detect_language(user_input)
                 keyword_source = "nltk"
                 keyword_generation_raw = ""
-                bing_results: List[dict] = []
-
-                keywords: List[str] = []
+                keywords = []
                 if response_type == "Normal":
                     gpt_keywords, keyword_generation_raw = generate_keywords_with_gpt(user_input, lang)
                     if gpt_keywords:
@@ -891,8 +938,8 @@ def chatbot_page():
                     keywords = extract_keywords(user_input, lang)
                     keyword_source = "nltk" if keywords else keyword_source
 
-                results: List[dict] = []
-                search_attempts: List[Tuple[str, int]] = []
+                results = []
+                search_attempts = []
                 if keywords:
                     if keyword_source == "language_model":
                         results, search_attempts = query_dbms_with_keywords(dbms, keywords)
@@ -933,6 +980,22 @@ def chatbot_page():
                         "Raw keyword suggestion response: " + keyword_generation_raw
                     )
 
+                if agent_mode_enabled:
+                    target_files = _unique_preserve_order(
+                        result.get("name") for result in results if result.get("name")
+                    )
+                    if target_files:
+                        with st.spinner("🧠 Agent is summarizing documents..."):
+                            agent = get_document_agent()
+                            for file_name in target_files:
+                                summary_result = agent.summarise_document(file_name, dbms)
+                                if summary_result.summary_text:
+                                    agent_summary_results.append(summary_result)
+                                elif summary_result.reason:
+                                    st.warning(f"Agent could not summarise {file_name}: {summary_result.reason}")
+                    elif keywords:
+                        st.info("Agent mode enabled, but no documents were retrieved to summarise.")
+
                 if web_supplement_enabled:
                     assistant_reply_lines.append(
                         "When citing information from web supplements, format the citation as a Markdown link like `[Title](URL)` and include it in the final 'Sources:' line."
@@ -954,6 +1017,20 @@ def chatbot_page():
                             "Bing web supplement returned no usable results. If you rely on general knowledge, end with 'Sources: No sources cited.'"
                         )
 
+                if agent_mode_enabled:
+                    if agent_summary_results:
+                        assistant_reply_lines.append(
+                            "Agent analysed the full documents listed below. Use their summaries in the following context and cite the original file names."
+                        )
+                        for summary in agent_summary_results:
+                            assistant_reply_lines.append(
+                                f"- `{summary.file_name}` (summary stored as `{summary.summary_name}`)"
+                            )
+                    else:
+                        assistant_reply_lines.append(
+                            "Agent mode is enabled, but no summaries were available for this query."
+                        )
+
                 assistant_reply = "\n".join(assistant_reply_lines) + "\n\n"
 
                 if results:
@@ -973,12 +1050,57 @@ def chatbot_page():
                         "enough to search the documents."
                     )
 
+                if agent_summary_results:
+                    assistant_reply += "\nAgent-generated document overviews:\n\n"
+                    for summary in agent_summary_results:
+                        assistant_reply += f"### Agent summary for `{summary.file_name}`\n{summary.summary_text}\n\n"
+
                 assistant_reply += (
                     "\nAlways end the final response with a 'Sources:' line listing every citation or 'Sources: No sources cited.'"
                 )
 
-                st.session_state.pending_sources_default = _build_sources_default_line(results, bing_results)
+                combined_results = list(results)
+                if agent_summary_results:
+                    combined_results.extend(
+                        {
+                            "name": summary.summary_name or f"{summary.file_name} (agent summary)",
+                            "content": summary.summary_text,
+                        }
+                        for summary in agent_summary_results
+                    )
+
+                st.session_state.pending_sources_default = _build_sources_default_line(combined_results, bing_results)
                 st.session_state.messages.append({"role": "system", "content": assistant_reply})
+        else:
+            if agent_mode_enabled and st.session_state.get('processed_file_name'):
+                processed_name = st.session_state['processed_file_name']
+                with st.spinner("🧠 Agent is summarizing the uploaded file..."):
+                    agent = get_document_agent()
+                    summary_result = agent.summarise_document(processed_name, dbms)
+                if summary_result.summary_text:
+                    agent_summary_results.append(summary_result)
+                    if summary_result.created:
+                        st.success(f"Agent summary saved for {processed_name}.")
+                elif summary_result.reason:
+                    st.warning(f"Agent could not summarise {processed_name}: {summary_result.reason}")
+
+            if agent_summary_results:
+                summary_context_lines = [
+                    "AGENT SUMMARY CONTEXT (uploaded file):",
+                    "The agent analysed the active uploaded file and produced the summary below. Use it while answering and cite the original document name.",
+                ]
+                for summary in agent_summary_results:
+                    summary_context_lines.append(f"### Agent summary for `{summary.file_name}`\n{summary.summary_text}")
+                st.session_state.messages.append({"role": "system", "content": "\n\n".join(summary_context_lines)})
+
+                combined_results = [
+                    {
+                        "name": summary.summary_name or f"{summary.file_name} (agent summary)",
+                        "content": summary.summary_text,
+                    }
+                    for summary in agent_summary_results
+                ]
+                st.session_state.pending_sources_default = _build_sources_default_line(combined_results, [])
 
         with st.spinner("Arcana is thinking..."):
             try:

--- a/arcana/utils/document_agent.py
+++ b/arcana/utils/document_agent.py
@@ -1,0 +1,246 @@
+"""Utilities for Arcana's document analysis agent.
+
+The document agent is responsible for reading full documents from the
+indexed cache, producing structured summaries, and persisting the
+summaries back into the Fiber database for future retrieval.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+import chardet
+import pandas as pd
+from docx import Document
+from pptx import Presentation
+from PyPDF2 import PdfReader
+
+from arcana.core.config import CACHE_DIR, INDEX_FILE
+from arcana.utils.fiber import FiberDBMS
+from arcana.utils.indexing import extract_keywords, detect_language
+from arcana.utils.response import openai_api_call
+
+
+@dataclass
+class AgentSummaryResult:
+    """Outcome of a document summarisation request."""
+
+    file_name: str
+    summary_text: str = ""
+    summary_path: Optional[Path] = None
+    created: bool = False
+    reason: Optional[str] = None
+
+    @property
+    def summary_name(self) -> Optional[str]:
+        if self.summary_path is None:
+            return None
+        return self.summary_path.name
+
+
+class DocumentAgent:
+    """Agent that can read, reason about, and summarise documents."""
+
+    def __init__(self, cache_dir: Path | str = CACHE_DIR, summary_subdir: str = "Summaries"):
+        self.cache_dir = Path(cache_dir)
+        self.summary_dir = self.cache_dir / summary_subdir
+        self.summary_dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def summarise_document(self, file_name: str, dbms: FiberDBMS) -> AgentSummaryResult:
+        """Ensure a summary exists for ``file_name`` and return it."""
+
+        if not file_name:
+            return AgentSummaryResult(file_name=file_name, reason="Missing file name")
+
+        source_path = self._locate_file(file_name)
+        if source_path is None:
+            return AgentSummaryResult(
+                file_name=file_name,
+                reason="Original file could not be located in the cache directory.",
+            )
+
+        summary_path = self.summary_dir / f"{source_path.stem}_summary.md"
+
+        if summary_path.exists():
+            summary_text = summary_path.read_text(encoding="utf-8", errors="replace")
+            result = AgentSummaryResult(
+                file_name=file_name,
+                summary_text=summary_text,
+                summary_path=summary_path,
+                created=False,
+            )
+        else:
+            full_content = self._read_file_text(source_path)
+            if not full_content.strip():
+                return AgentSummaryResult(
+                    file_name=file_name,
+                    reason="File was empty or unreadable when attempting to summarise.",
+                )
+
+            summary_text = self._generate_summary(file_name, full_content)
+            if not summary_text.strip():
+                return AgentSummaryResult(
+                    file_name=file_name,
+                    reason="Language model returned an empty summary.",
+                )
+
+            summary_path.write_text(summary_text, encoding="utf-8")
+            result = AgentSummaryResult(
+                file_name=file_name,
+                summary_text=summary_text,
+                summary_path=summary_path,
+                created=True,
+            )
+
+        self._ensure_summary_indexed(result, dbms)
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _locate_file(self, file_name: str) -> Optional[Path]:
+        """Search ``CACHE_DIR`` for a file that matches ``file_name``."""
+
+        target_name = Path(file_name).name
+        for root, _, files in os.walk(self.cache_dir):
+            if target_name in files:
+                return Path(root) / target_name
+        return None
+
+    def _read_file_text(self, path: Path) -> str:
+        extension = path.suffix.lower()
+        try:
+            if extension == ".txt":
+                raw = path.read_bytes()
+                encoding = chardet.detect(raw)["encoding"] or "utf-8"
+                return raw.decode(encoding, errors="replace")
+            if extension == ".docx":
+                doc = Document(path)
+                return "\n".join(para.text for para in doc.paragraphs)
+            if extension == ".pptx":
+                presentation = Presentation(path)
+                slide_text: List[str] = []
+                for slide in presentation.slides:
+                    if slide.shapes.title:
+                        slide_text.append(slide.shapes.title.text)
+                    for shape in slide.shapes:
+                        if shape.has_text_frame:
+                            slide_text.append(shape.text_frame.text)  # type: ignore[attr-defined]
+                return "\n".join(slide_text)
+            if extension == ".pdf":
+                reader = PdfReader(str(path))
+                return "\n".join(page.extract_text() or "" for page in reader.pages)
+            if extension in {".csv", ".xls", ".xlsx"}:
+                if extension == ".csv":
+                    df = pd.read_csv(path)
+                else:
+                    df = pd.read_excel(path)
+                return df.to_string(index=False)
+        except Exception as exc:  # pragma: no cover - defensive I/O guard
+            return f"[Agent warning] Unable to read file {path.name}: {exc}"
+
+        # Fall back to a safe read for unknown formats
+        return path.read_text(encoding="utf-8", errors="replace")
+
+    def _chunk_content(self, content: str, chunk_size: int = 3500) -> List[str]:
+        cleaned = content.strip()
+        if len(cleaned) <= chunk_size:
+            return [cleaned]
+
+        paragraphs = [para.strip() for para in re.split(r"\n{2,}", cleaned) if para.strip()]
+        chunks: List[str] = []
+        buffer = ""
+        for para in paragraphs:
+            candidate = f"{buffer}\n\n{para}".strip() if buffer else para
+            if len(candidate) <= chunk_size:
+                buffer = candidate
+                continue
+
+            if buffer:
+                chunks.append(buffer)
+                buffer = ""
+
+            if len(para) <= chunk_size:
+                buffer = para
+                continue
+
+            for start in range(0, len(para), chunk_size):
+                chunks.append(para[start : start + chunk_size])
+
+        if buffer:
+            chunks.append(buffer)
+
+        return chunks
+
+    def _generate_summary(self, file_name: str, content: str) -> str:
+        chunks = self._chunk_content(content)
+        total = len(chunks)
+        summaries: List[str] = []
+
+        for idx, chunk in enumerate(chunks, start=1):
+            messages: Iterable[dict] = [
+                {
+                    "role": "system",
+                    "content": (
+                        "You are Arcana's document analysis agent. Read the provided "
+                        "document section in full and produce a concise yet thorough "
+                        "summary. Capture the main ideas, important definitions, data "
+                        "tables, and any actionable steps. Provide the summary as "
+                        "clear bullet points."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": (
+                        f"Document: {file_name}\n"
+                        f"Section {idx} of {total}. Summarise all important content.\n\n{chunk}"
+                    ),
+                },
+            ]
+
+            stream = openai_api_call(messages, "Long Text")
+            chunk_summary = "".join(piece for piece in stream).strip()
+            if chunk_summary:
+                header = f"### Section {idx} of {total}\n{chunk_summary}"
+                summaries.append(header)
+
+        if not summaries:
+            return ""
+
+        combined = (
+            f"# Agent Summary for {file_name}\n\n"
+            "This summary was generated by Arcana's agent after reading the full document.\n\n"
+            + "\n\n".join(summaries)
+        )
+        return combined.strip()
+
+    def _ensure_summary_indexed(self, result: AgentSummaryResult, dbms: FiberDBMS) -> None:
+        if not result.summary_text:
+            return
+
+        summary_name = result.summary_name or f"{result.file_name}_summary"
+
+        existing = any(entry.get("name") == summary_name for entry in dbms.database)
+        if existing:
+            return
+
+        lang = detect_language(result.summary_text)
+        keywords = extract_keywords(result.summary_text, lang)
+        dbms.add_entry(name=summary_name, content=result.summary_text, tags=keywords)
+        dbms.save(INDEX_FILE)
+
+
+def get_document_agent() -> DocumentAgent:
+    """Return a singleton ``DocumentAgent`` instance."""
+
+    if not hasattr(get_document_agent, "_instance"):
+        get_document_agent._instance = DocumentAgent()
+    return get_document_agent._instance  # type: ignore[attr-defined]
+


### PR DESCRIPTION
## Summary
- introduce a document agent utility that reads full cached files, generates structured summaries, and indexes them for future chats
- wire the chatbot page to drive the agent when "Agent Mode" is enabled, injecting the generated summaries into the model context and citation defaults
- refresh the chat input toolbar with styling for web search, assistant modes, and the new agent toggle

## Testing
- `python -m compileall arcana/pages/chatbot.py arcana/utils/document_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68eb60d7d77483318d63c0e0d942eefb