### PR TITLE
Add diagnostics tab, style guide management, and export tools

### DIFF
--- a/arcana/pages/components/__init__.py
+++ b/arcana/pages/components/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable UI components for Streamlit pages."""

--- a/arcana/pages/components/style_guides.py
+++ b/arcana/pages/components/style_guides.py
@@ -1,0 +1,102 @@
+"""Streamlit widgets for managing reusable style guides."""
+
+from __future__ import annotations
+
+from typing import List
+
+import streamlit as st
+
+from arcana.utils.style_guides import (
+    ensure_style_guide_dir,
+    list_style_guides,
+    load_style_guide,
+    save_style_guide,
+    save_uploaded_style_guide,
+)
+
+
+def render_style_guide_controls(
+    *,
+    selection_key: str = "active_style_guides",
+    context_key: str = "global",
+    expanded: bool = False,
+) -> List[str]:
+    """Render selection and management controls for style guides."""
+
+    ensure_style_guide_dir()
+    available = list_style_guides()
+
+    current_selection: List[str] = st.session_state.get(selection_key, [])
+    current_selection = [name for name in current_selection if name in available]
+    st.session_state[selection_key] = current_selection
+
+    upload_key = f"{context_key}_style_guide_upload"
+    name_key = f"{context_key}_style_guide_name"
+    content_key = f"{context_key}_style_guide_content"
+    preview_key = f"{context_key}_style_guide_preview"
+    save_key = f"{context_key}_style_guide_save"
+
+    with st.expander("Style guides", expanded=expanded):
+        st.caption(
+            "Select one or more guides to enforce their rules. Upload existing files or author new guides below."
+        )
+
+        selected = st.multiselect(
+            "Active style guides",
+            options=available,
+            default=current_selection,
+            key=selection_key,
+            help="Guides apply to both rewrite generation and quality checks.",
+        )
+
+        uploaded = st.file_uploader(
+            "Upload guide (.txt or .md)",
+            type=["txt", "md", "markdown"],
+            key=upload_key,
+        )
+        if uploaded is not None:
+            try:
+                save_uploaded_style_guide(uploaded.name, uploaded.getvalue())
+                st.success(f"Saved '{uploaded.name}' to the style guide library.")
+                st.session_state.pop(upload_key, None)
+                st.rerun()
+            except ValueError as exc:
+                st.error(str(exc))
+
+        name_value = st.text_input(
+            "New guide name",
+            value=st.session_state.get(name_key, ""),
+            key=name_key,
+            placeholder="e.g., Marketing voice",
+        )
+        content_value = st.text_area(
+            "Guide rules",
+            value=st.session_state.get(content_key, ""),
+            key=content_key,
+            height=150,
+        )
+        if st.button("Save style guide", key=save_key):
+            try:
+                save_style_guide(name_value, content_value)
+            except ValueError as exc:  # Name or content validation failed
+                st.error(str(exc))
+            else:
+                st.success(f"Saved style guide '{name_value}'.")
+                st.session_state.pop(name_key, None)
+                st.session_state.pop(content_key, None)
+                st.rerun()
+
+        if available:
+            preview_options = ["(Select a guide)"] + available
+            preview_choice = st.selectbox(
+                "Preview a guide",
+                options=preview_options,
+                key=preview_key,
+            )
+            if preview_choice and preview_choice != "(Select a guide)":
+                try:
+                    st.code(load_style_guide(preview_choice), language="markdown")
+                except FileNotFoundError:
+                    st.warning("Selected style guide could not be loaded.")
+
+        return selected

--- a/arcana/pages/editor.py
+++ b/arcana/pages/editor.py
@@ -4,8 +4,10 @@ from typing import Any, Dict, List
 import streamlit as st
 from openai.types.chat import ChatCompletionMessageParam
 
+from arcana.pages.components.style_guides import render_style_guide_controls
 from arcana.utils.diff import generate_inline_diff_html, generate_version_diff_html
 from arcana.utils.response import openai_api_call
+from arcana.utils.style_guides import get_style_guide_rules
 
 
 def editor_page():
@@ -29,6 +31,8 @@ def editor_page():
         st.session_state.version_history = []
     if "pending_revert" not in st.session_state:
         st.session_state.pending_revert = None
+    if "active_style_guides" not in st.session_state:
+        st.session_state.active_style_guides = []
 
     # --- History Tab ---
     with st.expander("📚 Version History", expanded=False):
@@ -107,6 +111,9 @@ def editor_page():
 
     # Column 2: AI Controls and Edited Output
     with col2:
+        active_guides = render_style_guide_controls(context_key="editor")
+        if active_guides:
+            st.caption("Active guides: " + ", ".join(active_guides))
         st.subheader("AI Assistant")
         edit_prompt = st.text_input(
             "Editing Instruction",
@@ -119,14 +126,19 @@ def editor_page():
         if st.button("🚀 Run AI Edit", type="primary", disabled=is_disabled):
             with st.spinner("AI is editing your document... Please wait."):
                 # Construct messages for the API call with the correct type hint
+                style_rules = get_style_guide_rules(st.session_state.get("active_style_guides", []))
+                system_content = (
+                    "You are an expert editor. You will be given a piece of text and an instruction."
+                    " Your task is to rewrite the text based *only* on the instruction. Return nothing but the"
+                    " fully rewritten text, without any introductory phrases like 'Here is the revised text.'"
+                )
+                if style_rules:
+                    system_content += "\nFollow these style guide rules while editing:\n" + style_rules
+
                 messages: List[ChatCompletionMessageParam] = [
                     {
                         "role": "system",
-                        "content": (
-                            "You are an expert editor. You will be given a piece of text and an instruction."
-                            " Your task is to rewrite the text based *only* on the instruction. Return nothing but the"
-                            " fully rewritten text, without any introductory phrases like 'Here is the revised text.'"
-                        ),
+                        "content": system_content,
                     },
                     {
                         "role": "user",

--- a/arcana/pages/refiner.py
+++ b/arcana/pages/refiner.py
@@ -3,15 +3,20 @@
 from __future__ import annotations
 
 import datetime
+import io
 import re
 import uuid
 from typing import Any, Dict, List, Optional
 
 import streamlit as st
+from docx import Document
 from openai.types.chat import ChatCompletionMessageParam
 
+from arcana.pages.components.style_guides import render_style_guide_controls
 from arcana.utils.diff import generate_inline_diff_html
 from arcana.utils.response import openai_api_call
+from arcana.utils.style_guides import get_style_guide_rules
+from arcana.utils.text_metrics import TextMetrics, calculate_text_metrics
 
 
 REWRITE_PRESETS: List[Dict[str, str]] = [
@@ -64,6 +69,18 @@ def _ensure_refiner_state() -> None:
         st.session_state.refiner_focus_prompt = ""
     if "refiner_feedback" not in st.session_state:
         st.session_state.refiner_feedback = ""
+    if "active_style_guides" not in st.session_state:
+        st.session_state.active_style_guides: List[str] = []
+    if "refiner_quality_checks" not in st.session_state:
+        st.session_state.refiner_quality_checks = ""
+    if "refiner_last_metrics" not in st.session_state:
+        st.session_state.refiner_last_metrics: Optional[Dict[str, float]] = None
+    if "refiner_prev_metrics" not in st.session_state:
+        st.session_state.refiner_prev_metrics: Optional[Dict[str, float]] = None
+    if "refiner_last_text" not in st.session_state:
+        st.session_state.refiner_last_text = st.session_state.refiner_raw_text
+    if "refiner_export_include_citations" not in st.session_state:
+        st.session_state.refiner_export_include_citations = True
 
 
 def _get_preset(preset_key: str) -> Optional[Dict[str, str]]:
@@ -85,14 +102,21 @@ def _split_sentences(text: str) -> List[str]:
 
 def _append_history(source_text: str, rewritten_text: str, label: str, focus: str = "") -> None:
     timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    source_metrics = calculate_text_metrics(source_text)
+    rewritten_metrics = calculate_text_metrics(rewritten_text)
     entry = {
         "timestamp": timestamp,
         "label": label,
         "focus": focus,
         "source_text": source_text,
         "rewritten_text": rewritten_text,
+        "source_metrics": source_metrics.to_dict(),
+        "metrics": rewritten_metrics.to_dict(),
     }
     st.session_state.refiner_history.insert(0, entry)
+    st.session_state.refiner_prev_metrics = source_metrics.to_dict()
+    st.session_state.refiner_last_metrics = rewritten_metrics.to_dict()
+    st.session_state.refiner_last_text = rewritten_text
 
 
 def _find_candidate(candidate_id: str) -> Optional[Dict[str, Any]]:
@@ -108,16 +132,226 @@ def _build_messages(source_text: str, preset: Dict[str, str], focus_prompt: str)
         "Rewrite the following text according to the goal. Provide only the rewritten passage without commentary."
         f"\n\nGoal: {preset['instruction']}{focus_suffix}\n\nText:\n{source_text}"
     )
+    style_rules = get_style_guide_rules(st.session_state.get("active_style_guides", []))
+    system_content = (
+        "You are an expert writing assistant who rewrites content to match a requested style."
+        " Respond only with the fully rewritten text."
+    )
+    if style_rules:
+        system_content += "\nIncorporate these style guide rules when rewriting:\n" + style_rules
     return [
         {
             "role": "system",
-            "content": (
-                "You are an expert writing assistant who rewrites content to match a requested style."
-                " Respond only with the fully rewritten text."
-            ),
+            "content": system_content,
         },
         {"role": "user", "content": user_content},
     ]
+
+
+def _build_check_messages(text: str) -> List[ChatCompletionMessageParam]:
+    """Compose messages for the quality-check assistant."""
+
+    style_rules = get_style_guide_rules(st.session_state.get("active_style_guides", []))
+    system_prompt = (
+        "You are an editorial quality analyst."
+        " Review drafts for clarity, grammar, tone consistency, and alignment with any supplied style guides."
+        " Respond with a markdown-formatted report using bullet lists and short sections."
+    )
+    if style_rules:
+        system_prompt += "\nRespect the following style guide directives when assessing the text:\n" + style_rules
+
+    user_prompt = (
+        "Assess the following draft. Summarize key strengths, list the most important opportunities"
+        " for improvement, and call out any high-severity issues (grammar, consistency, inclusivity)."
+        " Provide actionable suggestions and reference style guide expectations when relevant."
+        f"\n\nDraft:\n{text}"
+    )
+
+    return [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_prompt},
+    ]
+
+
+def _build_metric_entries(current: TextMetrics, previous: Optional[TextMetrics]) -> List[Dict[str, Optional[str]]]:
+    """Return formatted metric rows for display and export."""
+
+    entries: List[Dict[str, Optional[str]]] = []
+
+    def delta_str(current_value: float, previous_value: Optional[float], *, precision: int = 0, suffix: str = "") -> Optional[str]:
+        if previous_value is None:
+            return None
+        difference = current_value - previous_value
+        if precision == 0:
+            formatted = f"{difference:+.0f}"
+        else:
+            formatted = f"{difference:+.{precision}f}"
+        return formatted + suffix
+
+    prev_word = previous.word_count if previous else None
+    prev_avg = previous.avg_sentence_length if previous else None
+    prev_flesch = previous.flesch_reading_ease if previous else None
+    prev_passive = previous.passive_voice_ratio if previous else None
+
+    entries.append(
+        {
+            "label": "Word count",
+            "value": str(current.word_count),
+            "delta": delta_str(current.word_count, prev_word),
+        }
+    )
+    entries.append(
+        {
+            "label": "Average sentence length",
+            "value": f"{current.avg_sentence_length:.2f} words",
+            "delta": delta_str(current.avg_sentence_length, prev_avg, precision=2, suffix=" words"),
+        }
+    )
+    entries.append(
+        {
+            "label": "Flesch Reading Ease",
+            "value": f"{current.flesch_reading_ease:.2f}",
+            "delta": delta_str(current.flesch_reading_ease, prev_flesch, precision=2),
+        }
+    )
+    passive_value = f"{current.passive_voice_count} sentences ({current.passive_voice_ratio:.2f}%)"
+    passive_delta = delta_str(current.passive_voice_ratio, prev_passive, precision=2, suffix=" pts")
+    entries.append(
+        {
+            "label": "Passive voice",
+            "value": passive_value,
+            "delta": passive_delta,
+        }
+    )
+
+    return entries
+
+
+def _create_docx_report(
+    *,
+    text: str,
+    metrics_entries: List[Dict[str, Optional[str]]],
+    quality_check: str,
+    style_guides: List[str],
+    include_citations: bool,
+    history: List[Dict[str, Any]],
+) -> bytes:
+    document = Document()
+    document.add_heading("Arcana Rewrite Report", level=1)
+    generated_ts = datetime.datetime.now().strftime("Generated on %Y-%m-%d %H:%M")
+    document.add_paragraph(generated_ts)
+
+    if style_guides:
+        document.add_paragraph("Style guides applied: " + ", ".join(style_guides))
+
+    document.add_heading("Current Draft", level=2)
+    document.add_paragraph(text if text.strip() else "(Draft is currently empty.)")
+
+    document.add_heading("Quality Metrics", level=2)
+    table = document.add_table(rows=1, cols=3)
+    hdr_cells = table.rows[0].cells
+    hdr_cells[0].text = "Metric"
+    hdr_cells[1].text = "Current"
+    hdr_cells[2].text = "Δ"
+    for entry in metrics_entries:
+        row_cells = table.add_row().cells
+        row_cells[0].text = entry["label"]
+        row_cells[1].text = entry["value"]
+        row_cells[2].text = entry.get("delta") or ""
+
+    document.add_heading("Quality Check", level=2)
+    if quality_check and quality_check.strip():
+        for raw_line in quality_check.strip().splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            if line.startswith("#"):
+                heading_level = min(line.count("#"), 5)
+                document.add_heading(line.lstrip("# "), level=min(heading_level + 1, 5))
+            elif line.startswith(('- ', '* ')):
+                document.add_paragraph(line[2:].strip(), style="List Bullet")
+            else:
+                document.add_paragraph(line)
+    else:
+        document.add_paragraph("Quality check has not been run yet.")
+
+    document.add_heading("Applied Fixes", level=2)
+    if history:
+        for idx, entry in enumerate(history, start=1):
+            prefix = f"[Fix {idx}] " if include_citations else ""
+            label = entry.get("label", "Unnamed fix")
+            timestamp = entry.get("timestamp", "")
+            focus = entry.get("focus")
+            paragraph = document.add_paragraph(style="List Number")
+            paragraph.add_run(f"{prefix}{label}")
+            if timestamp:
+                paragraph.add_run(f" — {timestamp}")
+            if focus:
+                paragraph.add_run(f" (Focus: {focus})")
+    else:
+        document.add_paragraph("No fixes have been applied yet.")
+
+    buffer = io.BytesIO()
+    document.save(buffer)
+    buffer.seek(0)
+    return buffer.getvalue()
+
+
+def _create_markdown_report(
+    *,
+    text: str,
+    metrics_entries: List[Dict[str, Optional[str]]],
+    quality_check: str,
+    style_guides: List[str],
+    include_citations: bool,
+    history: List[Dict[str, Any]],
+) -> str:
+    lines: List[str] = []
+    lines.append("# Arcana Rewrite Report")
+    lines.append("")
+    lines.append(f"_Generated on {datetime.datetime.now().strftime('%Y-%m-%d %H:%M')}_")
+    if style_guides:
+        lines.append("")
+        lines.append("**Style guides applied:** " + ", ".join(style_guides))
+
+    lines.append("")
+    lines.append("## Current Draft")
+    lines.append("")
+    lines.append(text.strip() or "(Draft is currently empty.)")
+
+    lines.append("")
+    lines.append("## Quality Metrics")
+    lines.append("")
+    lines.append("| Metric | Current | Δ |")
+    lines.append("| --- | --- | --- |")
+    for entry in metrics_entries:
+        delta = entry.get("delta") or ""
+        lines.append(f"| {entry['label']} | {entry['value']} | {delta} |")
+
+    lines.append("")
+    lines.append("## Quality Check")
+    lines.append("")
+    if quality_check and quality_check.strip():
+        lines.append(quality_check.strip())
+    else:
+        lines.append("Quality check has not been run yet.")
+
+    lines.append("")
+    lines.append("## Applied Fixes")
+    lines.append("")
+    if history:
+        for idx, entry in enumerate(history, start=1):
+            prefix = f"[Fix {idx}] " if include_citations else ""
+            label = entry.get("label", "Unnamed fix")
+            timestamp = entry.get("timestamp", "")
+            focus = entry.get("focus")
+            detail = f" — {timestamp}" if timestamp else ""
+            focus_suffix = f" _(Focus: {focus})_" if focus else ""
+            lines.append(f"- {prefix}{label}{detail}{focus_suffix}")
+    else:
+        lines.append("- No fixes have been applied yet.")
+
+    return "\n".join(lines)
 
 
 def _generate_rewrites(selected_keys: List[str], focus_prompt: str) -> None:
@@ -234,7 +468,7 @@ def grammar_refiner_page() -> None:
     if not st.session_state.refiner_merge_text:
         st.session_state.refiner_merge_origin = st.session_state.refiner_raw_text
 
-    tab_studio, tab_history = st.tabs(["Rewrite studio", "History"])
+    tab_studio, tab_diagnostics, tab_history = st.tabs(["Rewrite studio", "Diagnostics", "History"])
 
     with tab_studio:
         col_main, col_side = st.columns([3, 2])
@@ -267,6 +501,9 @@ def grammar_refiner_page() -> None:
                     _generate_rewrites(selected_keys, st.session_state.refiner_focus_prompt)
 
         with col_side:
+            active_guides = render_style_guide_controls(context_key="refiner")
+            if active_guides:
+                st.caption("Active guides: " + ", ".join(active_guides))
             st.subheader("Snippet clipboard")
             st.caption("Collect snippets from candidates or jot down your own notes to copy later.")
             st.text_area(
@@ -356,6 +593,103 @@ def grammar_refiner_page() -> None:
                             _add_sentences_to_merge(candidate["id"], selection_key)
                             st.session_state.refiner_feedback = "Selected sentences added to the merge workspace."
                             st.rerun()
+
+    with tab_diagnostics:
+        st.subheader("Quality metrics")
+        current_text = st.session_state.refiner_raw_text
+        current_metrics = calculate_text_metrics(current_text)
+
+        last_metrics_dict = st.session_state.get("refiner_last_metrics")
+        prev_metrics_dict = st.session_state.get("refiner_prev_metrics")
+        last_text = st.session_state.get("refiner_last_text")
+
+        previous_dict: Optional[Dict[str, float]] = None
+        if last_metrics_dict is None:
+            previous_dict = None
+        elif current_text != last_text:
+            previous_dict = last_metrics_dict
+        else:
+            previous_dict = prev_metrics_dict
+
+        previous_metrics = (
+            TextMetrics.from_dict(previous_dict) if previous_dict else None
+        )
+
+        metrics_entries = _build_metric_entries(current_metrics, previous_metrics)
+
+        metric_columns = st.columns(2)
+        for index, entry in enumerate(metrics_entries):
+            with metric_columns[index % 2]:
+                st.metric(entry["label"], entry["value"], entry.get("delta"))
+
+        st.caption(
+            "Flesch Reading Ease scores range from 0 (difficult) to 100 (very easy)."
+        )
+
+        if last_text != current_text:
+            st.session_state.refiner_prev_metrics = last_metrics_dict or current_metrics.to_dict()
+            st.session_state.refiner_last_text = current_text
+        st.session_state.refiner_last_metrics = current_metrics.to_dict()
+
+        st.markdown("---")
+        st.subheader("Quality check")
+        check_disabled = not current_text.strip()
+        if st.button("🔍 Run quality check", key="refiner_run_check", disabled=check_disabled):
+            with st.spinner("Reviewing draft against style guides…"):
+                try:
+                    messages = _build_check_messages(current_text)
+                    stream = openai_api_call(messages, "Normal")  # type: ignore[arg-type]
+                    st.session_state.refiner_quality_checks = "".join(list(stream)).strip()
+                except Exception as exc:  # pylint: disable=broad-except
+                    st.error(f"Quality check failed: {exc}")
+
+        if st.session_state.refiner_quality_checks:
+            st.markdown(st.session_state.refiner_quality_checks)
+        else:
+            st.info("Run a quality check to generate an AI-powered diagnostic report.")
+
+        st.markdown("---")
+        st.subheader("Export")
+        st.checkbox(
+            "Include citations for applied fixes",
+            key="refiner_export_include_citations",
+            help="When enabled, applied fixes are labeled as [Fix n] in the export.",
+        )
+
+        style_guides = st.session_state.get("active_style_guides", [])
+        include_citations = st.session_state.refiner_export_include_citations
+        history_entries = st.session_state.get("refiner_history", [])
+
+        docx_bytes = _create_docx_report(
+            text=current_text,
+            metrics_entries=metrics_entries,
+            quality_check=st.session_state.refiner_quality_checks,
+            style_guides=style_guides,
+            include_citations=include_citations,
+            history=history_entries,
+        )
+        markdown_report = _create_markdown_report(
+            text=current_text,
+            metrics_entries=metrics_entries,
+            quality_check=st.session_state.refiner_quality_checks,
+            style_guides=style_guides,
+            include_citations=include_citations,
+            history=history_entries,
+        )
+
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        st.download_button(
+            "⬇️ Download report (.docx)",
+            data=docx_bytes,
+            file_name=f"arcana_refiner_report_{timestamp}.docx",
+            mime="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        )
+        st.download_button(
+            "⬇️ Download summary (.md)",
+            data=markdown_report,
+            file_name=f"arcana_refiner_report_{timestamp}.md",
+            mime="text/markdown",
+        )
 
     with tab_history:
         st.subheader("Accepted rewrites")

--- a/arcana/utils/style_guides.py
+++ b/arcana/utils/style_guides.py
@@ -1,0 +1,107 @@
+"""Helpers for managing reusable style guides."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable, List
+
+from arcana.core.config import DATA_DIR
+
+STYLE_GUIDES_DIR = DATA_DIR / "style_guides"
+_ALLOWED_EXTENSIONS = {".txt", ".md", ".markdown"}
+
+
+def ensure_style_guide_dir() -> Path:
+    """Ensure the style guides directory exists and return its path."""
+
+    STYLE_GUIDES_DIR.mkdir(parents=True, exist_ok=True)
+    return STYLE_GUIDES_DIR
+
+
+def _sanitize_filename(name: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9_\- ]+", "", name).strip()
+    cleaned = re.sub(r"\s+", "_", cleaned)
+    return cleaned
+
+
+def list_style_guides() -> List[str]:
+    """Return the available style guide names (without extensions)."""
+
+    ensure_style_guide_dir()
+    guides = []
+    for path in STYLE_GUIDES_DIR.iterdir():
+        if path.is_file() and path.suffix.lower() in _ALLOWED_EXTENSIONS:
+            guides.append(path.stem)
+    return sorted(set(guides))
+
+
+def _resolve_style_guide_path(name: str) -> Path:
+    ensure_style_guide_dir()
+    sanitized = _sanitize_filename(name)
+    if not sanitized:
+        raise ValueError("Style guide name must contain alphanumeric characters.")
+
+    for extension in _ALLOWED_EXTENSIONS:
+        candidate = STYLE_GUIDES_DIR / f"{sanitized}{extension}"
+        if candidate.exists():
+            return candidate
+
+    # Default to markdown extension when creating a new file
+    return STYLE_GUIDES_DIR / f"{sanitized}.md"
+
+
+def load_style_guide(name: str) -> str:
+    """Load the text content of the specified style guide."""
+
+    path = _resolve_style_guide_path(name)
+    if not path.exists():
+        raise FileNotFoundError(f"Style guide '{name}' was not found.")
+    return path.read_text(encoding="utf-8")
+
+
+def save_style_guide(name: str, content: str) -> Path:
+    """Create or overwrite a style guide with the supplied content."""
+
+    if not content.strip():
+        raise ValueError("Style guide content cannot be empty.")
+
+    path = _resolve_style_guide_path(name)
+    ensure_style_guide_dir()
+    path.write_text(content.strip() + "\n", encoding="utf-8")
+    return path
+
+
+def save_uploaded_style_guide(filename: str, data: bytes) -> Path:
+    """Persist an uploaded style guide file."""
+
+    if not data:
+        raise ValueError("Uploaded file has no content.")
+
+    base = Path(filename).stem
+    sanitized = _sanitize_filename(base) or "style_guide"
+    extension = Path(filename).suffix.lower()
+    if extension not in _ALLOWED_EXTENSIONS:
+        extension = ".md"
+
+    ensure_style_guide_dir()
+    target = STYLE_GUIDES_DIR / f"{sanitized}{extension}"
+    counter = 1
+    while target.exists() and target.read_bytes() != data:
+        target = STYLE_GUIDES_DIR / f"{sanitized}_{counter}{extension}"
+        counter += 1
+
+    target.write_bytes(data)
+    return target
+
+
+def get_style_guide_rules(names: Iterable[str]) -> str:
+    """Concatenate the content of the selected style guides."""
+
+    rules: List[str] = []
+    for name in names:
+        try:
+            rules.append(load_style_guide(name).strip())
+        except FileNotFoundError:
+            continue
+    return "\n\n".join(rule for rule in rules if rule)

--- a/arcana/utils/text_metrics.py
+++ b/arcana/utils/text_metrics.py
@@ -1,0 +1,102 @@
+"""Utilities for computing readability and style metrics."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import asdict, dataclass
+from typing import Dict, List
+
+_WORD_RE = re.compile(r"[A-Za-z0-9']+")
+_VOWEL_RE = re.compile(r"[aeiouy]+", re.I)
+_PASSIVE_PATTERN = re.compile(
+    r"\b(am|is|are|was|were|be|been|being)\s+(\w+ed|\w+en)\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class TextMetrics:
+    """Container for readability and usage metrics."""
+
+    word_count: int
+    sentence_count: int
+    avg_sentence_length: float
+    flesch_reading_ease: float
+    passive_voice_ratio: float
+    passive_voice_count: int
+    syllable_count: int
+
+    def to_dict(self) -> Dict[str, float]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, float]) -> "TextMetrics":
+        return cls(**data)
+
+
+def _split_sentences(text: str) -> List[str]:
+    stripped = text.strip()
+    if not stripped:
+        return []
+    sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", stripped) if s.strip()]
+    return sentences or [stripped]
+
+
+def _estimate_syllables(word: str) -> int:
+    cleaned = word.lower().strip()
+    if not cleaned:
+        return 0
+
+    cleaned = re.sub(r"[^a-z]", "", cleaned)
+    if not cleaned:
+        return 0
+
+    matches = list(_VOWEL_RE.finditer(cleaned))
+    syllables = len(matches)
+
+    if cleaned.endswith("e") and syllables > 1:
+        syllables -= 1
+
+    if not matches:
+        syllables = 1
+
+    return max(1, syllables)
+
+
+def calculate_text_metrics(text: str) -> TextMetrics:
+    """Calculate readability and style metrics for the supplied text."""
+
+    sentences = _split_sentences(text)
+    words = _WORD_RE.findall(text)
+
+    sentence_count = len(sentences)
+    word_count = len(words)
+    syllable_count = sum(_estimate_syllables(word) for word in words)
+
+    avg_sentence_length = word_count / sentence_count if sentence_count else 0.0
+    avg_sentence_length = round(avg_sentence_length, 2)
+
+    words_per_sentence = word_count / sentence_count if sentence_count else 0.0
+    syllables_per_word = syllable_count / word_count if word_count else 0.0
+
+    flesch = 206.835 - 1.015 * words_per_sentence - 84.6 * syllables_per_word
+    flesch = round(flesch, 2) if not math.isnan(flesch) else 0.0
+
+    passive_sentences = 0
+    for sentence in sentences:
+        if _PASSIVE_PATTERN.search(sentence):
+            passive_sentences += 1
+
+    passive_ratio = (passive_sentences / sentence_count * 100) if sentence_count else 0.0
+    passive_ratio = round(passive_ratio, 2)
+
+    return TextMetrics(
+        word_count=word_count,
+        sentence_count=sentence_count,
+        avg_sentence_length=avg_sentence_length,
+        flesch_reading_ease=flesch,
+        passive_voice_ratio=passive_ratio,
+        passive_voice_count=passive_sentences,
+        syllable_count=syllable_count,
+    )


### PR DESCRIPTION
## Summary
- add text metric calculations and style guide storage helpers to support diagnostics and custom prompts
- enhance the rewrite refiner with a diagnostics tab, quality check workflow, style guide awareness, and DOCX/Markdown exports
- expose reusable style guide controls and wire editor prompts to respect the selected guides

## Testing
- python -m compileall arcana

------
https://chatgpt.com/codex/tasks/task_e_68eb60fcf0a8833183ca196dbfcac644