### PR TITLE
Add Grammar Refiner navigation and settings toggles

### DIFF
--- a/Arcanalte.py
+++ b/Arcanalte.py
@@ -18,6 +18,7 @@ from arcana.pages.settings import settings_page
 from arcana.pages.mixup import mixup_page
 from arcana.pages.longresponse import longresponse_page
 from arcana.pages.editor import editor_page
+from arcana.pages.refiner import grammar_refiner_page
 
 # Import configurations
 from arcana.core.config import APP_TITLE, CACHE_DIR, INDEX_FILE
@@ -85,7 +86,7 @@ st.sidebar.title("Navigation")
 # --- Page Selection Logic ---
 # Define the pages
 main_pages = ["Introduction", "Files", "Citations", "Chatbot"]
-advanced_pages = ["Mixup", "Editor", "Long Response"]
+advanced_pages = ["Mixup", "Editor", "Long Response", "Grammar Refiner"]
 
 # Display main page buttons
 for page in main_pages:
@@ -155,6 +156,7 @@ pages = {
     "Mixup": mixup_page,
     "Editor": editor_page,
     "Long Response": longresponse_page,
+    "Grammar Refiner": grammar_refiner_page,
     "Settings": settings_page
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes for this development session are recorded here.
   - Removed redundant separate "Recent AI Code Fixes" section (merged into this changelog).
 - Robust DB reload logic after indexing using the existing `dbms` instance.
 - **CHANGELOG.md** to keep a persistent record of updates.
+- Grammar Refiner workspace wired into the main navigation and documented in the README.
+- Settings toggles for enabling Rewrite Refiner diagnostics and AI quality checks.
 
 ### Changed
 - `finder.py`:
@@ -27,7 +29,8 @@ All notable changes for this development session are recorded here.
 - `mixup.py`: improved placeholder handling, typing, and error suppression.
 - `chatbot.py`: added sidebar file uploader; prioritises uploaded files in responses.
 - `editor.py`, `response.py`, `longresponse.py`: fixed streaming and typing issues for a smoother user experience.
-- `Arcanalte.py`: modernised sidebar navigation with a collapsible advanced-tools section.
+- `Arcanalte.py`: modernised sidebar navigation with a collapsible advanced-tools section and Grammar Refiner hook-up.
+- `README.md`: expanded navigation guide with Rewrite Refiner workflows.
 
 ### Removed
 - Legacy radio-button navigation logic from `Arcanalte.py`.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,18 @@ New here? Don't worry, angel! Here's a quick rundown of the key concepts and how
  - Files will appear in the "Finder" section
  - Organize your data and click "Index to Database" to finalize it
  - Once indexing is complete, switch to "IDX" mode in Chatbot to begin querying your data!
+
+🧰 Advanced Tools:
+ - "Mixup" → Spin up slide decks and study docs from your indexed sources
+ - "Editor" → Polish drafts with guided rewriting prompts and inline diffs
+ - "Long Response" → Draft extended essays that stay grounded in your knowledge base
+ - "Grammar Refiner" → Generate multiple rewrites, compare diffs, and export quality reports
 ```
+
+### 🪄 Rewrite Refiner Highlights
+- Stream rewrite candidates side by side, merge your favorite sentences, and keep an audit trail of accepted fixes.
+- Dive into diagnostics for readability, passive voice tracking, and AI-authored quality reviews—toggle these from **Settings ▸ Rewrite Refiner** if you prefer a lighter workspace.
+- Export polished DOCX or Markdown reports that capture your style guides, metrics, and applied changes for easy sharing.
 
 ---
 

--- a/arcana/pages/refiner.py
+++ b/arcana/pages/refiner.py
@@ -468,6 +468,9 @@ def grammar_refiner_page() -> None:
     if not st.session_state.refiner_merge_text:
         st.session_state.refiner_merge_origin = st.session_state.refiner_raw_text
 
+    diagnostics_enabled = st.session_state.get("refiner_enable_diagnostics", True)
+    quality_checks_enabled = st.session_state.get("refiner_enable_quality_checks", True)
+
     tab_studio, tab_diagnostics, tab_history = st.tabs(["Rewrite studio", "Diagnostics", "History"])
 
     with tab_studio:
@@ -595,101 +598,107 @@ def grammar_refiner_page() -> None:
                             st.rerun()
 
     with tab_diagnostics:
-        st.subheader("Quality metrics")
-        current_text = st.session_state.refiner_raw_text
-        current_metrics = calculate_text_metrics(current_text)
-
-        last_metrics_dict = st.session_state.get("refiner_last_metrics")
-        prev_metrics_dict = st.session_state.get("refiner_prev_metrics")
-        last_text = st.session_state.get("refiner_last_text")
-
-        previous_dict: Optional[Dict[str, float]] = None
-        if last_metrics_dict is None:
-            previous_dict = None
-        elif current_text != last_text:
-            previous_dict = last_metrics_dict
+        if not diagnostics_enabled:
+            st.info("Enable the diagnostics panel from Settings to view rewrite metrics and exports.")
         else:
-            previous_dict = prev_metrics_dict
+            st.subheader("Quality metrics")
+            current_text = st.session_state.refiner_raw_text
+            current_metrics = calculate_text_metrics(current_text)
 
-        previous_metrics = (
-            TextMetrics.from_dict(previous_dict) if previous_dict else None
-        )
+            last_metrics_dict = st.session_state.get("refiner_last_metrics")
+            prev_metrics_dict = st.session_state.get("refiner_prev_metrics")
+            last_text = st.session_state.get("refiner_last_text")
 
-        metrics_entries = _build_metric_entries(current_metrics, previous_metrics)
+            previous_dict: Optional[Dict[str, float]] = None
+            if last_metrics_dict is None:
+                previous_dict = None
+            elif current_text != last_text:
+                previous_dict = last_metrics_dict
+            else:
+                previous_dict = prev_metrics_dict
 
-        metric_columns = st.columns(2)
-        for index, entry in enumerate(metrics_entries):
-            with metric_columns[index % 2]:
-                st.metric(entry["label"], entry["value"], entry.get("delta"))
+            previous_metrics = (
+                TextMetrics.from_dict(previous_dict) if previous_dict else None
+            )
 
-        st.caption(
-            "Flesch Reading Ease scores range from 0 (difficult) to 100 (very easy)."
-        )
+            metrics_entries = _build_metric_entries(current_metrics, previous_metrics)
 
-        if last_text != current_text:
-            st.session_state.refiner_prev_metrics = last_metrics_dict or current_metrics.to_dict()
-            st.session_state.refiner_last_text = current_text
-        st.session_state.refiner_last_metrics = current_metrics.to_dict()
+            metric_columns = st.columns(2)
+            for index, entry in enumerate(metrics_entries):
+                with metric_columns[index % 2]:
+                    st.metric(entry["label"], entry["value"], entry.get("delta"))
 
-        st.markdown("---")
-        st.subheader("Quality check")
-        check_disabled = not current_text.strip()
-        if st.button("🔍 Run quality check", key="refiner_run_check", disabled=check_disabled):
-            with st.spinner("Reviewing draft against style guides…"):
-                try:
-                    messages = _build_check_messages(current_text)
-                    stream = openai_api_call(messages, "Normal")  # type: ignore[arg-type]
-                    st.session_state.refiner_quality_checks = "".join(list(stream)).strip()
-                except Exception as exc:  # pylint: disable=broad-except
-                    st.error(f"Quality check failed: {exc}")
+            st.caption(
+                "Flesch Reading Ease scores range from 0 (difficult) to 100 (very easy)."
+            )
 
-        if st.session_state.refiner_quality_checks:
-            st.markdown(st.session_state.refiner_quality_checks)
-        else:
-            st.info("Run a quality check to generate an AI-powered diagnostic report.")
+            if last_text != current_text:
+                st.session_state.refiner_prev_metrics = last_metrics_dict or current_metrics.to_dict()
+                st.session_state.refiner_last_text = current_text
+            st.session_state.refiner_last_metrics = current_metrics.to_dict()
 
-        st.markdown("---")
-        st.subheader("Export")
-        st.checkbox(
-            "Include citations for applied fixes",
-            key="refiner_export_include_citations",
-            help="When enabled, applied fixes are labeled as [Fix n] in the export.",
-        )
+            st.markdown("---")
+            st.subheader("Quality check")
+            if not quality_checks_enabled:
+                st.info("Enable AI quality checks from Settings to run grammar diagnostics on demand.")
+            else:
+                check_disabled = not current_text.strip()
+                if st.button("🔍 Run quality check", key="refiner_run_check", disabled=check_disabled):
+                    with st.spinner("Reviewing draft against style guides…"):
+                        try:
+                            messages = _build_check_messages(current_text)
+                            stream = openai_api_call(messages, "Normal")  # type: ignore[arg-type]
+                            st.session_state.refiner_quality_checks = "".join(list(stream)).strip()
+                        except Exception as exc:  # pylint: disable=broad-except
+                            st.error(f"Quality check failed: {exc}")
 
-        style_guides = st.session_state.get("active_style_guides", [])
-        include_citations = st.session_state.refiner_export_include_citations
-        history_entries = st.session_state.get("refiner_history", [])
+                if st.session_state.refiner_quality_checks:
+                    st.markdown(st.session_state.refiner_quality_checks)
+                else:
+                    st.info("Run a quality check to generate an AI-powered diagnostic report.")
 
-        docx_bytes = _create_docx_report(
-            text=current_text,
-            metrics_entries=metrics_entries,
-            quality_check=st.session_state.refiner_quality_checks,
-            style_guides=style_guides,
-            include_citations=include_citations,
-            history=history_entries,
-        )
-        markdown_report = _create_markdown_report(
-            text=current_text,
-            metrics_entries=metrics_entries,
-            quality_check=st.session_state.refiner_quality_checks,
-            style_guides=style_guides,
-            include_citations=include_citations,
-            history=history_entries,
-        )
+            st.markdown("---")
+            st.subheader("Export")
+            st.checkbox(
+                "Include citations for applied fixes",
+                key="refiner_export_include_citations",
+                help="When enabled, applied fixes are labeled as [Fix n] in the export.",
+            )
 
-        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        st.download_button(
-            "⬇️ Download report (.docx)",
-            data=docx_bytes,
-            file_name=f"arcana_refiner_report_{timestamp}.docx",
-            mime="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-        )
-        st.download_button(
-            "⬇️ Download summary (.md)",
-            data=markdown_report,
-            file_name=f"arcana_refiner_report_{timestamp}.md",
-            mime="text/markdown",
-        )
+            style_guides = st.session_state.get("active_style_guides", [])
+            include_citations = st.session_state.refiner_export_include_citations
+            history_entries = st.session_state.get("refiner_history", [])
+
+            docx_bytes = _create_docx_report(
+                text=current_text,
+                metrics_entries=metrics_entries,
+                quality_check=st.session_state.refiner_quality_checks,
+                style_guides=style_guides,
+                include_citations=include_citations,
+                history=history_entries,
+            )
+            markdown_report = _create_markdown_report(
+                text=current_text,
+                metrics_entries=metrics_entries,
+                quality_check=st.session_state.refiner_quality_checks,
+                style_guides=style_guides,
+                include_citations=include_citations,
+                history=history_entries,
+            )
+
+            timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+            st.download_button(
+                "⬇️ Download report (.docx)",
+                data=docx_bytes,
+                file_name=f"arcana_refiner_report_{timestamp}.docx",
+                mime="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            )
+            st.download_button(
+                "⬇️ Download summary (.md)",
+                data=markdown_report,
+                file_name=f"arcana_refiner_report_{timestamp}.md",
+                mime="text/markdown",
+            )
 
     with tab_history:
         st.subheader("Accepted rewrites")

--- a/arcana/pages/settings.py
+++ b/arcana/pages/settings.py
@@ -6,6 +6,10 @@ def apply_theme():
 
     if "theme" not in st.session_state:
         st.session_state.theme = "Light"
+    if "refiner_enable_diagnostics" not in st.session_state:
+        st.session_state.refiner_enable_diagnostics = True
+    if "refiner_enable_quality_checks" not in st.session_state:
+        st.session_state.refiner_enable_quality_checks = True
 
     theme_css = """
     <style>
@@ -132,6 +136,22 @@ def settings_page():
         "Glass": "Glassmorphism-inspired mode with translucent panels and glowing typography.",
     }
     st.info(descriptions.get(st.session_state.theme, ""))
+
+    st.markdown("---")
+    st.subheader("Rewrite Refiner")
+    st.caption(
+        "Control advanced grammar tooling such as the diagnostics dashboard and AI-powered quality reports."
+    )
+    st.checkbox(
+        "Enable diagnostics panel",
+        key="refiner_enable_diagnostics",
+        help="Toggle the quality metrics view in the Rewrite Refiner workspace.",
+    )
+    st.checkbox(
+        "Allow AI quality checks",
+        key="refiner_enable_quality_checks",
+        help="When enabled, Arcana can run AI-powered grammar and style diagnostics on your draft.",
+    )
 
     # --- Update Log ---
     with st.expander("View Update Log"):


### PR DESCRIPTION
## Summary
- add the Grammar Refiner workspace to the advanced tools navigation
- document the rewrite refiner experience and changelog entry
- surface settings toggles for diagnostics and respect them within the refiner page

## Testing
- streamlit run Arcanalte.py --server.headless true --server.port 8501

------
https://chatgpt.com/codex/tasks/task_e_68eb6443c5d08331a4d1cfa4ad2ed1e3