### PR TITLE
Improve chatbot agent mode document coverage

### DIFF
--- a/arcana/pages/chatbot.py
+++ b/arcana/pages/chatbot.py
@@ -976,6 +976,31 @@ def chatbot_page():
             )
         st.markdown("</div>", unsafe_allow_html=True)
 
+    if "agent_manual_selection" not in st.session_state:
+        st.session_state["agent_manual_selection"] = []
+
+    if agent_mode_enabled:
+        agent_for_selection = get_document_agent()
+        available_agent_docs = agent_for_selection.list_available_documents()
+        with st.expander("Agent document selection", expanded=False):
+            st.caption(
+                "Select additional documents for the agent to read before it crafts a reply. "
+                "These files will be summarised alongside search results."
+            )
+            if available_agent_docs:
+                st.multiselect(
+                    "Additional documents for agent summaries",
+                    options=available_agent_docs,
+                    default=st.session_state.get("agent_manual_selection", []),
+                    key="agent_manual_selection",
+                    help=(
+                        "Choose any indexed document. The agent will process the selected files "
+                        "in full and store refreshed summaries for future conversations."
+                    ),
+                )
+            else:
+                st.info("No indexed documents were found in the cache directory yet.")
+
     if user_input:
         st.session_state.pending_sources_default = "Sources: No sources cited."
         st.session_state.messages.append({"role": "user", "content": user_input})
@@ -1058,16 +1083,74 @@ def chatbot_page():
                     target_files = _unique_preserve_order(
                         result.get("name") for result in results if result.get("name")
                     )
-                    if target_files:
+                    manual_agent_files = [
+                        file_name
+                        for file_name in st.session_state.get("agent_manual_selection", [])
+                        if file_name
+                    ]
+                    candidate_files = _unique_preserve_order(list(target_files) + manual_agent_files)
+
+                    if candidate_files:
+                        agent_progress_container = st.container()
+                        progress_placeholder = agent_progress_container.empty()
+                        progress_bar = agent_progress_container.progress(0.0)
+                        status_rows: List[dict] = []
+                        any_success = False
+                        agent = get_document_agent()
+                        total_candidates = len(candidate_files)
+
                         with st.spinner("🧠 Agent is summarizing documents..."):
-                            agent = get_document_agent()
-                            for file_name in target_files:
+                            for idx, file_name in enumerate(candidate_files, start=1):
+                                progress_placeholder.info(
+                                    f"Agent processing `{file_name}` ({idx}/{total_candidates})"
+                                )
                                 summary_result = agent.summarise_document(file_name, dbms)
                                 if summary_result.summary_text:
                                     agent_summary_results.append(summary_result)
-                                elif summary_result.reason:
-                                    st.warning(f"Agent could not summarise {file_name}: {summary_result.reason}")
-                    elif keywords:
+                                    any_success = True
+                                    status_rows.append(
+                                        {
+                                            "Document": file_name,
+                                            "Result": (
+                                                "Created new summary"
+                                                if summary_result.created
+                                                else "Reused cached summary"
+                                            ),
+                                            "Summary path": summary_result.citation_path or "—",
+                                        }
+                                    )
+                                else:
+                                    reason = summary_result.reason or "Unknown error"
+                                    st.warning(
+                                        f"Agent could not summarise {file_name}: {reason}"
+                                    )
+                                    status_rows.append(
+                                        {
+                                            "Document": file_name,
+                                            "Result": f"Failed: {reason}",
+                                            "Summary path": "—",
+                                        }
+                                    )
+                                progress_bar.progress(idx / total_candidates)
+
+                        progress_bar.progress(1.0)
+                        if any_success:
+                            progress_placeholder.success(
+                                "Agent finished summarising the selected documents."
+                            )
+                        else:
+                            progress_placeholder.warning(
+                                "Agent processed the requested documents but no summaries were generated."
+                            )
+
+                        if status_rows:
+                            status_df = pd.DataFrame(status_rows)
+                            status_df.index = status_df.index + 1
+                            agent_progress_container.dataframe(
+                                status_df,
+                                use_container_width=True,
+                            )
+                    elif keywords or manual_agent_files:
                         st.info("Agent mode enabled, but no documents were retrieved to summarise.")
 
                 if web_supplement_enabled:
@@ -1149,14 +1232,27 @@ def chatbot_page():
         else:
             if agent_mode_enabled and st.session_state.get('processed_file_name'):
                 processed_name = st.session_state['processed_file_name']
+                agent_progress_container = st.container()
+                progress_placeholder = agent_progress_container.empty()
+                progress_bar = agent_progress_container.progress(0.0)
                 with st.spinner("🧠 Agent is summarizing the uploaded file..."):
                     agent = get_document_agent()
+                    progress_placeholder.info(
+                        f"Agent processing `{processed_name}` (1/1)"
+                    )
                     summary_result = agent.summarise_document(processed_name, dbms)
+                progress_bar.progress(1.0)
                 if summary_result.summary_text:
+                    progress_placeholder.success(
+                        "Agent finished summarising the uploaded document."
+                    )
                     agent_summary_results.append(summary_result)
                     if summary_result.created:
                         st.success(f"Agent summary saved for {processed_name}.")
                 elif summary_result.reason:
+                    progress_placeholder.warning(
+                        "Agent processed the uploaded document but could not create a summary."
+                    )
                     st.warning(f"Agent could not summarise {processed_name}: {summary_result.reason}")
 
             if agent_summary_results:

--- a/arcana/utils/document_agent.py
+++ b/arcana/utils/document_agent.py
@@ -20,6 +20,7 @@ from pptx import Presentation
 from PyPDF2 import PdfReader
 
 from arcana.core.config import CACHE_DIR, INDEX_FILE
+from arcana.utils.document_catalog import DocumentCatalog
 from arcana.utils.fiber import FiberDBMS
 from arcana.utils.indexing import extract_keywords, detect_language
 from arcana.utils.response import openai_api_call
@@ -50,6 +51,15 @@ class DocumentAgent:
         self.cache_dir = Path(cache_dir)
         self.summary_dir = self.cache_dir / summary_subdir
         self.summary_dir.mkdir(parents=True, exist_ok=True)
+        self._catalog = DocumentCatalog(cache_dir=self.cache_dir, exclude_subdirs=(summary_subdir,))
+
+    # ------------------------------------------------------------------
+    # Discovery helpers
+    # ------------------------------------------------------------------
+    def list_available_documents(self) -> List[str]:
+        """Return a sorted list of document names known to the agent."""
+
+        return self._catalog.list_names()
 
     # ------------------------------------------------------------------
     # Public API
@@ -119,6 +129,10 @@ class DocumentAgent:
         if not file_name:
             return None
 
+        record = self._catalog.find(file_name)
+        if record:
+            return record.path
+
         candidate = Path(file_name)
         # Accept absolute paths that already point to a cached file.
         if candidate.is_absolute() and candidate.exists():
@@ -128,12 +142,16 @@ class DocumentAgent:
         # support nested paths stored in the search index.
         relative_candidate = self.cache_dir / candidate
         if relative_candidate.exists():
+            # Refresh the catalogue so future lookups benefit from the discovery.
+            self._catalog.refresh()
             return relative_candidate
 
         target_name = candidate.name
         for root, _, files in os.walk(self.cache_dir):
             if target_name in files:
-                return Path(root) / target_name
+                resolved = Path(root) / target_name
+                self._catalog.refresh()
+                return resolved
         return None
 
     def _read_file_text(self, path: Path) -> str:

--- a/arcana/utils/document_catalog.py
+++ b/arcana/utils/document_catalog.py
@@ -1,0 +1,136 @@
+"""Utilities for discovering indexed documents without relying on FiberDBMS.
+
+The agent mode in the chatbot needs to present users with a list of documents
+that can be summarised. Previously the only way to discover the available
+files was to query ``FiberDBMS`` which couples the UI to the database layer.
+This module provides a lightweight catalogue built directly from the cached
+files on disk so that other components can browse and resolve documents
+without touching the database implementation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from arcana.core.config import CACHE_DIR, SUPPORTED_FILE_TYPES
+
+
+@dataclass(frozen=True)
+class DocumentRecord:
+    """Metadata about an indexed document available to the agent."""
+
+    name: str
+    path: Path
+
+
+class DocumentCatalog:
+    """Catalogue of files stored in the cache directory.
+
+    The catalogue scans ``CACHE_DIR`` (or a caller supplied directory) and
+    stores both the full relative path as well as the basename for each file so
+    that callers can resolve documents even when only the filename is known.
+    The catalogue purposefully avoids touching ``FiberDBMS`` so it can be used
+    in contexts where the database layer is not available or should not be
+    accessed directly.
+    """
+
+    def __init__(
+        self,
+        cache_dir: Path | str = CACHE_DIR,
+        *,
+        allowed_extensions: Optional[Iterable[str]] = None,
+        exclude_subdirs: Optional[Sequence[str]] = None,
+    ) -> None:
+        self.cache_dir = Path(cache_dir)
+        extensions = allowed_extensions or SUPPORTED_FILE_TYPES
+        self.allowed_extensions = {f".{ext.lower().lstrip('.')}" for ext in extensions}
+        self.exclude_subdirs = {Path(subdir).parts[0] for subdir in (exclude_subdirs or [])}
+        self._by_name: Dict[str, DocumentRecord] = {}
+        self._by_basename: Dict[str, List[DocumentRecord]] = {}
+        self.refresh()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def refresh(self) -> None:
+        """Rescan the cache directory and rebuild the catalogue."""
+
+        self._by_name.clear()
+        self._by_basename.clear()
+
+        if not self.cache_dir.exists():
+            return
+
+        for path in self.cache_dir.rglob("*"):
+            if not path.is_file():
+                continue
+
+            if path.suffix.lower() and path.suffix.lower() not in self.allowed_extensions:
+                continue
+
+            try:
+                relative = path.relative_to(self.cache_dir)
+            except ValueError:
+                # The file is outside of the cache directory; skip it.
+                continue
+
+            if relative.parts and relative.parts[0] in self.exclude_subdirs:
+                continue
+
+            relative_name = relative.as_posix()
+            record = DocumentRecord(name=relative_name, path=path)
+            self._by_name[relative_name] = record
+            self._by_basename.setdefault(path.name.lower(), []).append(record)
+
+    def list_names(self) -> List[str]:
+        """Return all known document names sorted for display."""
+
+        return sorted(self._by_name.keys(), key=str.lower)
+
+    def find(self, file_name: str, *, refresh_on_miss: bool = True) -> Optional[DocumentRecord]:
+        """Locate a document by name or basename.
+
+        ``file_name`` can be an absolute path, a relative path within the cache
+        directory, or just the basename of the file. When ``refresh_on_miss`` is
+        true (the default) the catalogue will perform a one-time refresh if the
+        first lookup fails in case new files were added since the last scan.
+        """
+
+        if not file_name:
+            return None
+
+        candidate = Path(file_name)
+        if candidate.is_absolute() and candidate.exists():
+            return DocumentRecord(name=candidate.name, path=candidate)
+
+        normalised = self._normalise(candidate)
+        record = self._by_name.get(normalised)
+        if record:
+            return record
+
+        basename_matches = self._by_basename.get(candidate.name.lower())
+        if basename_matches:
+            if len(basename_matches) == 1:
+                return basename_matches[0]
+            # Prefer the shortest relative path to reduce ambiguity for users.
+            return min(basename_matches, key=lambda rec: len(rec.name))
+
+        if refresh_on_miss:
+            self.refresh()
+            return self.find(file_name, refresh_on_miss=False)
+
+        return None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalise(path: Path) -> str:
+        """Return a normalised posix-style representation of ``path``."""
+
+        return path.as_posix().lstrip("./")
+
+
+__all__ = ["DocumentCatalog", "DocumentRecord"]


### PR DESCRIPTION
## Summary
- add a filesystem-backed document catalogue so the agent can locate indexed files without calling into FiberDBMS
- extend the chatbot UI to let users pick additional documents for agent summaries and display per-document progress/status
- surface progress feedback when summarising uploaded files so users can see what the agent is processing

## Testing
- pytest *(fails: arcana/tests/test_mixed_formatting.py::test_parse_markdown_to_word_runs_ignores_triple_underscores)*

------
https://chatgpt.com/codex/tasks/task_e_68ed0c45bae48331a618314a9e5382ca